### PR TITLE
clear response buffer before using it

### DIFF
--- a/firmware/HttpClient.cpp
+++ b/firmware/HttpClient.cpp
@@ -158,6 +158,10 @@ void HttpClient::request(http_request_t &aRequest, http_response_t &aResponse, h
     Serial.println("HttpClient>\tEnd of HTTP Request.");
     #endif
 
+    // clear response buffer
+    memset(&buffer[0], 0, sizeof(buffer));
+
+
     //
     // Receive HTTP Response
     //


### PR DESCRIPTION
Given one makes two http requests. The first response is long, the second response is shorter. The second response also contained data from the first request. this should now be fixed
