### PR TITLE
fixed null termination of buffer

### DIFF
--- a/firmware/HttpClient.cpp
+++ b/firmware/HttpClient.cpp
@@ -219,6 +219,7 @@ void HttpClient::request(http_request_t &aRequest, http_response_t &aResponse, h
             }
             bufferPosition++;
         }
+        buffer[bufferPosition] = '\0'; // Null-terminate buffer
 
         #ifdef LOGGING
         if (bytes) {


### PR DESCRIPTION
This had the effect of never letting the string become shorter again when re-using the same response struct.
