### PR TITLE
Support PATCH as an HttpVerb

### DIFF
--- a/firmware/HttpClient.h
+++ b/firmware/HttpClient.h
@@ -12,6 +12,7 @@ static const char* HTTP_METHOD_GET    = "GET";
 static const char* HTTP_METHOD_POST   = "POST";
 static const char* HTTP_METHOD_PUT    = "PUT";
 static const char* HTTP_METHOD_DELETE = "DELETE";
+static const char* HTTP_METHOD_PATCH = "PATCH";
 
 /**
  * This struct is used to pass additional HTTP headers such as API-keys.
@@ -107,6 +108,11 @@ public:
     void del(http_request_t &aRequest, http_response_t &aResponse, http_header_t headers[])
     {
         request(aRequest, aResponse, headers, HTTP_METHOD_DELETE);
+    }
+	
+    void patch(http_request_t &aRequest, http_response_t &aResponse, http_header_t headers[])
+    {
+        request(aRequest, aResponse, headers, HTTP_METHOD_PATCH);
     }
 
 private:


### PR DESCRIPTION
[RFC5789](http://tools.ietf.org/html/rfc5789) defines the PATCH HttpVerb
for applying partial modifications to a resource.  For example, updating
a row in a database.  This is supported in a variety of frameworks
including [Rails](https://github.com/rails/rails/issues/348), [Azure Mobile Services](https://msdn.microsoft.com/en-us/library/azure/jj677198.aspx), and [ASP.NET](http://aspnetwebstack.codeplex.com/workitem/3).  This
changeset enables creating PATCH requests using HttpClient.