### PR TITLE
Fixed path for example "application.cpp"

### DIFF
--- a/firmware/examples/application.cpp
+++ b/firmware/examples/application.cpp
@@ -1,5 +1,5 @@
 #include "application.h"
-#include "HttpClient.h"
+#include "HttpClient/HttpClient.h"
 
 /**
 * Declaring the variables.


### PR DESCRIPTION
Hey, this looks good with one problem (fixed here). Examples actually need the path `Library_Name/Library.h` because of how the files are stored in the cloud. Increment your `spark.json`, reimport the library to build, and we're good to go!