### PR TITLE
A small bugfix and a change in behaviour (which should be transparent to the user).

### DIFF
--- a/firmware/HttpClient.cpp
+++ b/firmware/HttpClient.cpp
@@ -176,6 +176,8 @@ void HttpClient::request(http_request_t &aRequest, http_response_t &aResponse, h
     unsigned long firstRead = millis();
     bool error = false;
     bool timeout = false;
+    char lastChar = 0;
+    bool inHeaders = true;
 
     do {
         #ifdef LOGGING
@@ -204,6 +206,25 @@ void HttpClient::request(http_request_t &aRequest, http_response_t &aResponse, h
                 break;
             }
 
+            if (inHeaders) {
+                if ((c == '\n') && (lastChar == '\n')) {
+                    // End of headers.  Grab the status code and reset the buffer.
+                    aResponse.status = atoi(&buffer[9]);
+                    
+                    memset(&buffer[0], 0, sizeof(buffer));
+                    bufferPosition = 0;
+                    inHeaders = false;
+                    #ifdef LOGGING
+                    Serial.print("\r\nHttpClient>\tEnd of HTTP Headers (");
+                    Serial.print(aResponse.status);
+                    Serial.println(")");
+                    #endif
+                    continue;
+                } else if (c != '\r') {
+                    lastChar = c;
+                }
+            }
+
             // Check that received character fits in buffer before storing.
             if (bufferPosition < sizeof(buffer)-1) {
                 buffer[bufferPosition] = c;
@@ -213,12 +234,13 @@ void HttpClient::request(http_request_t &aRequest, http_response_t &aResponse, h
                 error = true;
 
                 #ifdef LOGGING
-                Serial.println("HttpClient>\tError: Response body larger than buffer.");
+                Serial.println("\r\nHttpClient>\tError: Response body larger than buffer.");
                 #endif
+                break;
             }
             bufferPosition++;
         }
-        buffer[bufferPosition] = '\0'; // Null-terminate buffer
+        // We don't need to null terminate the buffer since it was zeroed to start with, or null terminated when it reached capacity.
 
         #ifdef LOGGING
         if (bytes) {
@@ -246,18 +268,12 @@ void HttpClient::request(http_request_t &aRequest, http_response_t &aResponse, h
     #endif
     client.stop();
 
-    String raw_response(buffer);
-
-    // Not super elegant way of finding the status code, but it works.
-    String statusCode = raw_response.substring(9,12);
-
     #ifdef LOGGING
     Serial.print("HttpClient>\tStatus Code: ");
-    Serial.println(statusCode);
+    Serial.println(aResponse.status);
     #endif
 
-    int bodyPos = raw_response.indexOf("\r\n\r\n");
-    if (bodyPos == -1) {
+    if (inHeaders) {
         #ifdef LOGGING
         Serial.println("HttpClient>\tError: Can't find HTTP response body.");
         #endif
@@ -265,7 +281,5 @@ void HttpClient::request(http_request_t &aRequest, http_response_t &aResponse, h
         return;
     }
     // Return the entire message body from bodyPos+4 till end.
-    aResponse.body = "";
-    aResponse.body += raw_response.substring(bodyPos+4);
-    aResponse.status = atoi(statusCode.c_str());
+    aResponse.body = buffer;
 }


### PR DESCRIPTION
First there was a condition whereby a NULL would be written outside of the buffer when the buffer had previously reached capacity.  This would overwrite the first byte of whatever variable happened to be declared after the HttpClient object.  Setting the NULL was not required since the buffer was entirely zeroed before starting to copy the stream into it and a terminating NULL was already added when the buffer had been filled.  I've removed adding the NULL.

Second, I've modified when the detection of the headers and body are done.  Rather than the previous method, we now look for two "\n" characters in a row (ignoring any intervening "\r"'s) as the stream is being received.  When detected, we extract the status code and zero the buffer (we could save the headers at this point, but we were just throwing them away anyway), which allows the entire size of the buffer to receive body content without using additional memory.  We also avoid copying the buffer into a String at a later point to facilitate splitting, thus saving memory.