### PR TITLE
Hostname & Path changed to www.worldclockapi.com

### DIFF
--- a/firmware/examples/application.cpp
+++ b/firmware/examples/application.cpp
@@ -30,9 +30,9 @@ void loop() {
     Serial.println();
     Serial.println("Application>\tStart of Loop.");
     // Request path and body can be set at runtime or at setup.
-    request.hostname = "www.timeapi.org";
+    request.hostname = "www.worldclockapi.com";
     request.port = 80;
-    request.path = "/utc/now";
+    request.path = "/api/json/utc/now";
 
     // The library also supports sending a body with your request:
     //request.body = "{\"key\":\"value\"}";


### PR DESCRIPTION
[www.timeapi.org](www.timeapi.org) no longer exists and hence [www.timeapi.org/utc/now](www.timeapi.org/utc/now) gives the following error:
```
Application>	Response status: -1
Application>	HTTP Response Body:
```
Whereas [http://www.worldclockapi.com/api/json/utc/now](http://www.worldclockapi.com/api/json/utc/now) returns:
```
Application>	Response status: 200
Application>	HTTP Response Body: {"$id":"1","currentDateTime":"2018-12-19T11:07Z","utcOffset":"00:00:00","isDayLightSavingsTime":false,"dayOfTheWeek":"Wednesday","timeZoneName":"UTC","currentFileTime":131896912299228305,"ordinalDate":"2018-353","serviceResponse":null}

``` 